### PR TITLE
fix: update "changed_at" in inactive handler

### DIFF
--- a/app/Support/Status/InactiveHandler.php
+++ b/app/Support/Status/InactiveHandler.php
@@ -5,6 +5,7 @@ namespace App\Support\Status;
 use App\ServiceStatus;
 use App\Status;
 use App\Support\Utils;
+use Illuminate\Support\Carbon;
 
 class InactiveHandler
 {
@@ -28,6 +29,7 @@ class InactiveHandler
                     if ($elapsed >= $duration) {
                         $serviceStatus->status_id = $inactive;
                         $serviceStatus->updated_by = null;
+                        $serviceStatus->changed_at = Carbon::now();
                         $serviceStatus->save();
 
                         // Status has changed

--- a/tests/Unit/Support/Status/InactiveHandlerTest.php
+++ b/tests/Unit/Support/Status/InactiveHandlerTest.php
@@ -52,7 +52,6 @@ class InactiveHandlerTest extends TestCase
         // Mock inactivity period
         $duration = config('app.status_inactive_duration');
         Carbon::setTestNow($fakeNow->addSeconds($duration));
-
         InactiveHandler::handle();
 
         // Service status set to "inactive"
@@ -60,6 +59,7 @@ class InactiveHandlerTest extends TestCase
             'device_id' => $device->id,
             'service_id' => $service->id,
             'status_id' => $inactive->id,
+            'changed_at' => $fakeNow->toDateTimeString(),
         ]);
 
         // Event added to service history


### PR DESCRIPTION
Service status `changed_at` update was missing in "inactive" handler, resulting in bad duration displayed in application.

Unfortunately, this fix will impact only new services statuses changes.
